### PR TITLE
feat: parse graph from JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Public API for **symbolic path enumeration** on directed graphs.
 Build **structural matrices** and enumerate the **MDNF** (all simple s→t paths).
 
 ```bash
-go get github.com/hdalab/ga@v0.1.0
+go get github.com/hdalab/ga@v0.1.1
 ```
 
 ### Quick example
@@ -31,6 +31,8 @@ i: 2->5
 S: 0
 T: 5
 `))
+    // alternatively:
+    // spec, _ := ga.ParseJson([]byte(`{"n":6,"edges":[{"id":"a","from":0,"to":1},{"id":"b","from":0,"to":2},{"id":"c","from":1,"to":2},{"id":"d","from":1,"to":3},{"id":"e","from":2,"to":3},{"id":"f","from":2,"to":4},{"id":"g","from":3,"to":4},{"id":"h","from":4,"to":5},{"id":"i","from":2,"to":5}],"s":0,"t":5}`))
     var paths []ga.Path
     ga.EnumerateMDNF(context.Background(), &spec.G, spec.S, spec.T, ga.EnumOptions{}, func(p ga.Path) bool {
         paths = append(paths, p); return true

--- a/io_json.go
+++ b/io_json.go
@@ -1,0 +1,57 @@
+package ga
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ParseJson parses a graph specification in JSON format:
+//
+//	{
+//	  "n": 6,
+//	  "edges": [{"id":"a","from":0,"to":1}, ...],
+//	  "s": 0,
+//	  "t": 5
+//	}
+func ParseJson(b []byte) (*Spec, error) {
+	var js struct {
+		N     int `json:"n"`
+		Edges []struct {
+			ID   string `json:"id"`
+			From int    `json:"from"`
+			To   int    `json:"to"`
+		} `json:"edges"`
+		S *int `json:"s"`
+		T *int `json:"t"`
+	}
+	if err := json.Unmarshal(b, &js); err != nil {
+		return nil, err
+	}
+	if js.S == nil || js.T == nil {
+		return nil, fmt.Errorf("s and t must be provided")
+	}
+	edges := make([]Edge, len(js.Edges))
+	maxv := -1
+	for i, e := range js.Edges {
+		edges[i] = Edge{ID: e.ID, From: e.From, To: e.To}
+		if e.From > maxv {
+			maxv = e.From
+		}
+		if e.To > maxv {
+			maxv = e.To
+		}
+	}
+	if *js.S > maxv {
+		maxv = *js.S
+	}
+	if *js.T > maxv {
+		maxv = *js.T
+	}
+	n := js.N
+	if n <= 0 || n < maxv+1 {
+		n = maxv + 1
+	}
+	g := Graph{N: n, Edges: edges}
+	g.BuildAdj()
+	return &Spec{G: g, S: *js.S, T: *js.T}, nil
+}

--- a/io_json_test.go
+++ b/io_json_test.go
@@ -1,0 +1,38 @@
+package ga
+
+import "testing"
+
+func TestParseJson(t *testing.T) {
+	gexp := `a: 0->1
+b: 0->2
+c: 1->2
+d: 1->3
+e: 2->3
+f: 2->4
+g: 3->4
+h: 4->5
+i: 2->5
+S: 0
+T: 5
+`
+	spec1, err := ParseGexp([]byte(gexp))
+	if err != nil {
+		t.Fatalf("ParseGexp: %v", err)
+	}
+	jsonSpec := `{"n":6,"edges":[{"id":"a","from":0,"to":1},{"id":"b","from":0,"to":2},{"id":"c","from":1,"to":2},{"id":"d","from":1,"to":3},{"id":"e","from":2,"to":3},{"id":"f","from":2,"to":4},{"id":"g","from":3,"to":4},{"id":"h","from":4,"to":5},{"id":"i","from":2,"to":5}],"s":0,"t":5}`
+	spec2, err := ParseJson([]byte(jsonSpec))
+	if err != nil {
+		t.Fatalf("ParseJson: %v", err)
+	}
+	if spec1.G.N != spec2.G.N || spec1.S != spec2.S || spec1.T != spec2.T {
+		t.Fatalf("spec mismatch: %+v vs %+v", spec1, spec2)
+	}
+	if len(spec1.G.Edges) != len(spec2.G.Edges) {
+		t.Fatalf("edge count mismatch: %d vs %d", len(spec1.G.Edges), len(spec2.G.Edges))
+	}
+	for i, e := range spec1.G.Edges {
+		if e != spec2.G.Edges[i] {
+			t.Fatalf("edge %d mismatch: %v vs %v", i, e, spec2.G.Edges[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add `ParseJson` to build graph specs from JSON
- document JSON parsing and bump module version to v0.1.1
- test JSON parser against existing GEXP format

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68aa1e595db8832391bc44189e3026fb