### PR TITLE
track dfs nodes and prunes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,10 @@ T: 5
     fmt.Println(ga.MDNF(paths))
 }
 ```
+
+### Stats
+
+`EnumerateMDNF` returns `Stats` with two useful metrics:
+
+- `NodesExpanded` — how many times DFS expanded a vertex;
+- `Pruned` — how many edges were skipped either due to revisiting a vertex or a global reachability check.

--- a/enum_dfsminor.go
+++ b/enum_dfsminor.go
@@ -1,54 +1,84 @@
 package ga
 
 import (
-    "context"
-    "time"
+	"context"
+	"time"
 )
 
 func dfsminorEnumerate(ctx context.Context, g *Graph, s, t int, opt EnumOptions, emit func(Path) bool) (Stats, error) {
-    start := time.Now()
-    reachS := ReachableFrom(g, s)
-    reachT := ReachableTo(g, t)
+	start := time.Now()
+	reachS := ReachableFrom(g, s)
+	reachT := ReachableTo(g, t)
 
-    visited := make([]bool, g.N)
-    var nodes []int
-    if opt.WithNodes { nodes = []int{s} }
-    visited[s] = true
-    curEdges := []string{}
-    var stats Stats
-    var stop bool
+	visited := make([]bool, g.N)
+	var nodes []int
+	if opt.WithNodes {
+		nodes = []int{s}
+	}
+	visited[s] = true
+	curEdges := []string{}
+	var stats Stats
+	var stop bool
 
-    var dfs func(u int)
-    dfs = func(u int) {
-        if stop { return }
-        select { case <-ctx.Done(): stop = true; return; default: }
-        if u == t {
-            stats.NumPaths++
-            p := Path{EdgeIDs: append([]string(nil), curEdges...)}
-            if opt.WithNodes {
-                p.Nodes = append([]int(nil), nodes...)
-            }
-            if !emit(p) { stop = true }
-            return
-        }
-        for _, ei := range g.Out[u] {
-            e := g.Edges[ei]; v := e.To
-            if visited[v] { continue }
-            if !reachS[u] || !reachT[v] { continue }
-            visited[v] = true
-            curEdges = append(curEdges, e.ID)
-            if opt.WithNodes { nodes = append(nodes, v) }
-            dfs(v)
-            if opt.WithNodes { nodes = nodes[:len(nodes)-1] }
-            curEdges = curEdges[:len(curEdges)-1]
-            visited[v] = false
-            if stop { return }
-            if opt.MaxPaths > 0 && stats.NumPaths >= opt.MaxPaths { stop = true; return }
-        }
-    }
+	var dfs func(u int)
+	dfs = func(u int) {
+		if stop {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			stop = true
+			return
+		default:
+		}
+		stats.NodesExpanded++
+		if u == t {
+			stats.NumPaths++
+			p := Path{EdgeIDs: append([]string(nil), curEdges...)}
+			if opt.WithNodes {
+				p.Nodes = append([]int(nil), nodes...)
+			}
+			if !emit(p) {
+				stop = true
+			}
+			return
+		}
+		for _, ei := range g.Out[u] {
+			e := g.Edges[ei]
+			v := e.To
+			if visited[v] {
+				stats.Pruned++
+				continue
+			}
+			if !reachS[u] || !reachT[v] {
+				stats.Pruned++
+				continue
+			}
+			visited[v] = true
+			curEdges = append(curEdges, e.ID)
+			if opt.WithNodes {
+				nodes = append(nodes, v)
+			}
+			dfs(v)
+			if opt.WithNodes {
+				nodes = nodes[:len(nodes)-1]
+			}
+			curEdges = curEdges[:len(curEdges)-1]
+			visited[v] = false
+			if stop {
+				return
+			}
+			if opt.MaxPaths > 0 && stats.NumPaths >= opt.MaxPaths {
+				stop = true
+				return
+			}
+		}
+	}
 
-    dfs(s)
-    stats.ElapsedNS = time.Since(start).Nanoseconds()
-    if stats.NumPaths > 0 { stats.NsPerPath = float64(stats.ElapsedNS) / float64(stats.NumPaths) }
-    return stats, ctx.Err()
+	dfs(s)
+	stats.ElapsedNS = time.Since(start).Nanoseconds()
+	if stats.NumPaths > 0 {
+		stats.NsPerPath = float64(stats.ElapsedNS) / float64(stats.NumPaths)
+	}
+	return stats, ctx.Err()
 }

--- a/enum_dfsminor_test.go
+++ b/enum_dfsminor_test.go
@@ -1,0 +1,83 @@
+package ga
+
+import (
+	"context"
+	"testing"
+)
+
+// DAG with a dead end: 0->1->2->3 (T), plus 1->4 which doesn't lead to T.
+func TestStatsPrunedReachability(t *testing.T) {
+	g := New(5)
+	g.AddEdge("a", 0, 1)
+	g.AddEdge("b", 1, 2)
+	g.AddEdge("c", 2, 3)
+	g.AddEdge("x", 1, 4)
+	g.BuildAdj()
+
+	stats, err := EnumerateMDNF(context.Background(), g, 0, 3, EnumOptions{}, func(Path) bool { return true })
+	if err != nil {
+		t.Fatalf("EnumerateMDNF: %v", err)
+	}
+	if stats.NumPaths != 1 {
+		t.Fatalf("NumPaths = %d, want 1", stats.NumPaths)
+	}
+	if stats.Pruned < 1 {
+		t.Fatalf("Pruned = %d, want >=1", stats.Pruned)
+	}
+	if stats.NodesExpanded <= 0 {
+		t.Fatalf("NodesExpanded = %d, want >0", stats.NodesExpanded)
+	}
+}
+
+// Graph with a cycle via back edge 2->1.
+func TestStatsPrunedVisited(t *testing.T) {
+	g := New(4)
+	g.AddEdge("a", 0, 1)
+	g.AddEdge("b", 1, 2)
+	g.AddEdge("c", 2, 3)
+	g.AddEdge("back", 2, 1)
+	g.BuildAdj()
+
+	stats, err := EnumerateMDNF(context.Background(), g, 0, 3, EnumOptions{}, func(Path) bool { return true })
+	if err != nil {
+		t.Fatalf("EnumerateMDNF: %v", err)
+	}
+	if stats.NumPaths != 1 {
+		t.Fatalf("NumPaths = %d, want 1", stats.NumPaths)
+	}
+	if stats.Pruned < 1 {
+		t.Fatalf("Pruned = %d, want >=1", stats.Pruned)
+	}
+	if stats.NodesExpanded <= 0 {
+		t.Fatalf("NodesExpanded = %d, want >0", stats.NodesExpanded)
+	}
+}
+
+// Example from README (a..i edges).
+func TestExampleStats(t *testing.T) {
+	g := New(6)
+	g.AddEdge("a", 0, 1)
+	g.AddEdge("b", 0, 2)
+	g.AddEdge("c", 1, 2)
+	g.AddEdge("d", 1, 3)
+	g.AddEdge("e", 2, 3)
+	g.AddEdge("f", 2, 4)
+	g.AddEdge("g", 3, 4)
+	g.AddEdge("h", 4, 5)
+	g.AddEdge("i", 2, 5)
+	g.BuildAdj()
+
+	stats, err := EnumerateMDNF(context.Background(), g, 0, 5, EnumOptions{}, func(Path) bool { return true })
+	if err != nil {
+		t.Fatalf("EnumerateMDNF: %v", err)
+	}
+	if stats.NumPaths != 7 {
+		t.Fatalf("NumPaths = %d, want 7", stats.NumPaths)
+	}
+	if stats.Pruned != 0 {
+		t.Fatalf("Pruned = %d, want 0", stats.Pruned)
+	}
+	if stats.NodesExpanded <= 0 {
+		t.Fatalf("NodesExpanded = %d, want >0", stats.NodesExpanded)
+	}
+}


### PR DESCRIPTION
## Summary
- count DFS node expansions and pruned edges in MDNF enumerator
- document Stats metrics in README
- add tests covering pruned paths due to reachability and cycles plus README example

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68aa373ed8dc8323a2f1d58164814898