### PR TITLE
Add language selection and localized docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,6 @@
-# ga — Graph Algebra (Go module)
+# ga — Graph Algebra
 
-Public API for **symbolic path enumeration** on directed graphs.
-Build **structural matrices** and enumerate the **MDNF** (all simple s→t paths).
+Select language / Выберите язык:
 
-```bash
-go get github.com/hdalab/ga@v0.1.1
-```
-
-### Quick example
-```go
-package main
-
-import (
-    "context"
-    "fmt"
-    "github.com/hdalab/ga"
-)
-
-func main() {
-    spec, _ := ga.ParseGexp([]byte(`
-a: 0->1
-b: 0->2
-c: 1->2
-d: 1->3
-e: 2->3
-f: 2->4
-g: 3->4
-h: 4->5
-i: 2->5
-S: 0
-T: 5
-`))
-    // alternatively:
-    // spec, _ := ga.ParseJson([]byte(`{"n":6,"edges":[{"id":"a","from":0,"to":1},{"id":"b","from":0,"to":2},{"id":"c","from":1,"to":2},{"id":"d","from":1,"to":3},{"id":"e","from":2,"to":3},{"id":"f","from":2,"to":4},{"id":"g","from":3,"to":4},{"id":"h","from":4,"to":5},{"id":"i","from":2,"to":5}],"s":0,"t":5}`))
-    var paths []ga.Path
-    ga.EnumerateMDNF(context.Background(), &spec.G, spec.S, spec.T, ga.EnumOptions{}, func(p ga.Path) bool {
-        paths = append(paths, p); return true
-    })
-    fmt.Println(ga.MDNF(paths))
-}
-```
-
-Edges added with `AddEdge` automatically update adjacency lists; `BuildAdj`
-can be used to rebuild them if the edge list is modified directly.
-
-### Stats
-
-`EnumerateMDNF` returns `Stats` with two useful metrics:
-
-- `NodesExpanded` — how many times DFS expanded a vertex;
-- `Pruned` — how many edges were skipped either due to revisiting a vertex or a global reachability check.
+- [English](docs/README.en.md)
+- [Русский](docs/README.ru.md)

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -1,0 +1,52 @@
+# ga — Graph Algebra (Go module)
+
+Public API for **symbolic path enumeration** on directed graphs.
+Build **structural matrices** and enumerate the **MDNF** (all simple s→t paths).
+
+```bash
+go get github.com/hdalab/ga@v0.1.1
+```
+
+### Quick example
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "github.com/hdalab/ga"
+)
+
+func main() {
+    spec, _ := ga.ParseGexp([]byte(`
+a: 0->1
+b: 0->2
+c: 1->2
+d: 1->3
+e: 2->3
+f: 2->4
+g: 3->4
+h: 4->5
+i: 2->5
+S: 0
+T: 5
+`))
+    // alternatively:
+    // spec, _ := ga.ParseJson([]byte(`{"n":6,"edges":[{"id":"a","from":0,"to":1},{"id":"b","from":0,"to":2},{"id":"c","from":1,"to":2},{"id":"d","from":1,"to":3},{"id":"e","from":2,"to":3},{"id":"f","from":2,"to":4},{"id":"g","from":3,"to":4},{"id":"h","from":4,"to":5},{"id":"i","from":2,"to":5}],"s":0,"t":5}`))
+    var paths []ga.Path
+    ga.EnumerateMDNF(context.Background(), &spec.G, spec.S, spec.T, ga.EnumOptions{}, func(p ga.Path) bool {
+        paths = append(paths, p); return true
+    })
+    fmt.Println(ga.MDNF(paths))
+}
+```
+
+Edges added with `AddEdge` automatically update adjacency lists; `BuildAdj`
+can be used to rebuild them if the edge list is modified directly.
+
+### Stats
+
+`EnumerateMDNF` returns `Stats` with two useful metrics:
+
+- `NodesExpanded` — how many times DFS expanded a vertex;
+- `Pruned` — how many edges were skipped either due to revisiting a vertex or a global reachability check.

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -1,0 +1,52 @@
+# ga — Алгебра графов (Go модуль)
+
+Публичный API для **символьного перечисления путей** на направленных графах.
+Стройте **структурные матрицы** и перечисляйте **МДНФ** (все простые пути s→t).
+
+```bash
+go get github.com/hdalab/ga@v0.1.1
+```
+
+### Быстрый пример
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "github.com/hdalab/ga"
+)
+
+func main() {
+    spec, _ := ga.ParseGexp([]byte(`
+a: 0->1
+b: 0->2
+c: 1->2
+d: 1->3
+e: 2->3
+f: 2->4
+g: 3->4
+h: 4->5
+i: 2->5
+S: 0
+T: 5
+`))
+    // альтернативный вариант:
+    // spec, _ := ga.ParseJson([]byte(`{"n":6,"edges":[{"id":"a","from":0,"to":1},{"id":"b","from":0,"to":2},{"id":"c","from":1,"to":2},{"id":"d","from":1,"to":3},{"id":"e","from":2,"to":3},{"id":"f","from":2,"to":4},{"id":"g","from":3,"to":4},{"id":"h","from":4,"to":5},{"id":"i","from":2,"to":5}],"s":0,"t":5}`))
+    var paths []ga.Path
+    ga.EnumerateMDNF(context.Background(), &spec.G, spec.S, spec.T, ga.EnumOptions{}, func(p ga.Path) bool {
+        paths = append(paths, p); return true
+    })
+    fmt.Println(ga.MDNF(paths))
+}
+```
+
+Рёбра, добавленные с помощью `AddEdge`, автоматически обновляют списки смежности; `BuildAdj`
+может использоваться для их пересборки, если список рёбер был изменён напрямую.
+
+### Статистика
+
+`EnumerateMDNF` возвращает `Stats` с двумя полезными метриками:
+
+- `NodesExpanded` — сколько раз DFS расширял вершину;
+- `Pruned` — сколько рёбер было пропущено либо из-за повторного посещения вершины, либо из-за глобальной проверки достижимости.


### PR DESCRIPTION
## Summary
- add English and Russian documentation in new `docs` directory
- replace top-level README with language selector linking to localized docs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68aa58e0208c83239b5f5edacba0750a